### PR TITLE
[server] plugins - envelop

### DIFF
--- a/examples/express/src/server.ts
+++ b/examples/express/src/server.ts
@@ -1,4 +1,5 @@
 import { createServer } from '@ptsq/server';
+import { Plugin, plugin } from '@ptsq/server/dist/plugin';
 import { Type } from '@sinclair/typebox';
 import express, { Request, Response } from 'express';
 
@@ -9,8 +10,22 @@ const createContext = ({ req, res }: { req: Request; res: Response }) => {
   return { req, res, user, test: { a: 1 } };
 };
 
+const p = plugin(() => ({
+  onRequest: () => {
+    return {
+      onResponse: () => {},
+    };
+  },
+  onExecute: ({ meta }) => {
+    return {
+      onExecuteDone: ({ response }) => {},
+    };
+  },
+}));
+
 const { router, resolver, serve } = createServer({
   ctx: createContext,
+  plugins: [p],
 });
 
 const loggingResolver = resolver.use(async ({ next }) => {

--- a/packages/server/src/createServer.ts
+++ b/packages/server/src/createServer.ts
@@ -8,7 +8,7 @@ import type {
   inferContextParamsFromContextBuilder,
 } from './context';
 import type { CORSOptions } from './cors';
-import type { ErrorFormatter } from './errorFormatter';
+import type { Plugin } from './plugin';
 import { Resolver } from './resolver';
 import { Router, type AnyRouter, type Routes } from './router';
 import { serve as _serve } from './serve';
@@ -22,8 +22,8 @@ type CreateServerArgs<TContextBuilder extends ContextBuilder> = {
   fetchAPI?: FetchAPI;
   root?: string;
   endpoint?: string;
-  errorFormatter?: ErrorFormatter;
   compiler?: Compiler;
+  plugins?: Plugin[];
 };
 
 /**
@@ -46,8 +46,8 @@ export const createServer = <TContextBuilder extends ContextBuilder>({
   fetchAPI,
   root = '',
   endpoint = '/ptsq',
-  errorFormatter = (error) => error,
   compiler = new Compiler(),
+  plugins = [],
 }: CreateServerArgs<TContextBuilder>) => {
   type RootContext = inferContextFromContextBuilder<TContextBuilder>;
   type ContextBuilderParams =
@@ -101,6 +101,7 @@ export const createServer = <TContextBuilder extends ContextBuilder>({
         method: 'POST',
         handler: async (req, ctxParams) => {
           const requestBody = await req.json();
+          console.log(plugins);
 
           const serverResponse = await _serve({
             router: baseRouter,
@@ -110,7 +111,7 @@ export const createServer = <TContextBuilder extends ContextBuilder>({
             compiler,
           });
 
-          return serverResponse.toResponse(errorFormatter);
+          return serverResponse.toResponse();
         },
       })
       .route({

--- a/packages/server/src/hook.ts
+++ b/packages/server/src/hook.ts
@@ -1,0 +1,66 @@
+import type { MaybePromise } from '../dist/types';
+import type { Context } from './context';
+import type { OnErrorHook } from './hooks/onErrorHook';
+import type { OnExecuteDoneHook } from './hooks/onExecuteDoneHook';
+import type { OnExecuteHook } from './hooks/onExecuteHook';
+import type { OnRequestHook } from './hooks/onRequestHook';
+import type { OnResponseHook } from './hooks/OnResponseHook';
+import type { HTTPError } from './httpError';
+import type { MiddlewareMeta, MiddlewareResponse } from './middleware';
+
+export class Hook {
+  _def: Partial<HookDefinition>;
+
+  constructor(def: Partial<HookDefinition>) {
+    this._def = def;
+  }
+
+  onError(error: HTTPError): MaybePromise<HTTPError | undefined | null> {
+    if (!this._def.onError) return error;
+
+    return this._def.onError(error);
+  }
+
+  async onRequest(options: {
+    request: Request;
+  }): Promise<{ request: Request }> {
+    if (!this._def.onRequest) return options;
+
+    const onRequestResult = await this._def.onRequest(options);
+
+    this._def.onResponse = onRequestResult?.onResponse;
+
+    return { ...options, request: onRequestResult?.request ?? options.request };
+  }
+
+  async onResponse(options: {
+    response: Response;
+  }): Promise<{ response: Response }> {
+    if (!this._def.onResponse) return options;
+
+    const onResponseResult = await this._def.onResponse(options);
+
+    return {
+      ...options,
+      response: onResponseResult?.response ?? options.response,
+    };
+  }
+
+  async onExecute(options: { meta: MiddlewareMeta }) {
+    const onExecuteResult = await this._def.onExecute?.(options);
+
+    this._def.onExecuteDone = onExecuteResult?.onExecuteDone;
+  }
+
+  onExecuteDone(options: { response: MiddlewareResponse<Context> }) {
+    this._def.onExecuteDone?.(options);
+  }
+}
+
+export type HookDefinition = {
+  onError: OnErrorHook;
+  onRequest: OnRequestHook;
+  onResponse: OnResponseHook;
+  onExecute: OnExecuteHook;
+  onExecuteDone: OnExecuteDoneHook;
+};

--- a/packages/server/src/hooks/onErrorHook.ts
+++ b/packages/server/src/hooks/onErrorHook.ts
@@ -1,0 +1,6 @@
+import type { HTTPError } from '../httpError';
+import type { MaybePromise } from '../types';
+
+export type OnErrorHook = (
+  error: HTTPError,
+) => MaybePromise<HTTPError | null | undefined>;

--- a/packages/server/src/hooks/onExecuteDoneHook.ts
+++ b/packages/server/src/hooks/onExecuteDoneHook.ts
@@ -1,0 +1,6 @@
+import type { Context } from '../context';
+import type { MiddlewareResponse } from '../middleware';
+
+export type OnExecuteDoneHook = (options: {
+  response: MiddlewareResponse<Context>;
+}) => void;

--- a/packages/server/src/hooks/onExecuteHook.ts
+++ b/packages/server/src/hooks/onExecuteHook.ts
@@ -1,0 +1,12 @@
+import type { MaybePromise } from 'rollup';
+import type { MiddlewareMeta } from 'src/middleware';
+import type { OnExecuteDoneHook } from './onExecuteDoneHook';
+
+export type OnExecuteHook = (options: { meta: MiddlewareMeta }) => MaybePromise<
+  | {
+      onExecuteDone?: OnExecuteDoneHook;
+    }
+  | undefined
+  // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+  | void
+>;

--- a/packages/server/src/hooks/onRequestHook.ts
+++ b/packages/server/src/hooks/onRequestHook.ts
@@ -1,0 +1,12 @@
+import type { MaybePromise } from '../types';
+import type { OnResponseHook } from './OnResponseHook';
+
+export type OnRequestHook = (options: { request: Request }) => MaybePromise<
+  | {
+      request?: Request;
+      onResponse?: OnResponseHook;
+    }
+  | undefined
+  // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+  | void
+>;

--- a/packages/server/src/hooks/onResponseHook.ts
+++ b/packages/server/src/hooks/onResponseHook.ts
@@ -1,0 +1,10 @@
+import type { MaybePromise } from '../types';
+
+export type OnResponseHook = (options: { response: Response }) => MaybePromise<
+  | {
+      response?: Response;
+    }
+  | undefined
+  // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+  | void
+>;

--- a/packages/server/src/plugin.ts
+++ b/packages/server/src/plugin.ts
@@ -1,0 +1,9 @@
+import type { OnErrorHook } from './hooks/onErrorHook';
+import type { OnExecuteHook } from './hooks/onExecuteHook';
+import type { OnRequestHook } from './hooks/onRequestHook';
+
+export type Plugin = {
+  onError?: OnErrorHook;
+  onRequest?: OnRequestHook;
+  onExecute?: OnExecuteHook;
+};


### PR DESCRIPTION
# Plugins (envelop)

plugins (envelop) allows you to wrap the application and customize some behaviors.

```ts
const useErrorFormatter = (cb) => new Plugin({
  onError: (error /* HTTPError */) => cb(error)
})
```

## With TS

```ts
const useRequest = new Plugin<{ req: express.Request }>({
  onRequest: ({ ctx } /* { ctx:  express.Request, ... } */) => { ... }
})
```

## Usage

```ts
createServer({
  plugins: [
     useErrorFormatter((error /* HTTPError */) => null)
  ]
})
```

## Events (lifecycle)

* onError - called every time the error occured
* onExecute - called before every query or mutation execution (right before resolve)
* onExecuteDone - called after every query or mutation execution (right after resolve before output validation)
* onValidate - called after args validation and output validation
* onRequest - called on every request (no validated data, raw request)
* onResponse - called on every response (after everything validated and done, before sending to client)
* onPluginInit - called on plugin initialization

## Benefits

Allows you to create custom plugins which do something like formatting error, masking errors in production, logging, etc.
You can also add or remove something from request or response, so allows you to access the low level request and response.

## Testing

```ts
describe('My Plugin', () => {
  it('Should run correctly with no errors', async () => {
    myPlugin.envelop(query).call(...)
  })
})
```

### Multiple plugins test

```ts
describe('My Plugins', () => {
  it('Should run correctly with no errors', async () => {
    myPluginB.envelop(myPluginA.envelop(query)).call(...)
  })
})
```

## usage maybe

Maybe the plugin system should be applied to resolver.

```ts
const resolverWithErrorFormatter = resolver.plugin(useErrorFormatter(() => null)).plugin(...).plugin(...);
```

or

```ts
const resolverWithErrorFormatter = resolver.envelop(useErrorFormatter(() => null)).envelop(...).envelop(...);
```